### PR TITLE
Criação de um query para telas menores que 600px

### DIFF
--- a/fluido/css/home.css
+++ b/fluido/css/home.css
@@ -17,8 +17,8 @@
 
 .slider {
     display: block;
-    height: 266.67px;;
-    width: clamp(176.211px, 26.33vw, 400px);
+    height: clamp(100px, 25vw, 266.67px);
+    width: clamp(176.211px, 25vw, 400px);
     margin: auto;
     position: relative;
 }
@@ -82,4 +82,35 @@
 .highlights-title{
     font-size: clamp(0.65em, 1.369vw, 1.3em);
     margin-left: 5px;
+}
+
+@media screen and (max-width: 900px) {
+    .welcoming-section {
+        padding: 0;
+        width: 100%;
+        text-align: center;
+        height: auto;
+    }
+
+    .side-message {
+        float: none;
+        width: 100%;
+        max-width: 100%;
+        font-size: clamp(8px, 3.291vw, 50px);
+        font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
+    }
+    
+    .restaurant-slideshow {
+        float: none;
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .slider {
+        display: block;
+        height: clamp(150px, 26vw, 266.67px);
+        width: clamp(220px, 32vw, 500px);
+        margin: auto;
+        position: relative;
+    }
 }

--- a/fluido/css/premium-sushi.css
+++ b/fluido/css/premium-sushi.css
@@ -20,7 +20,7 @@
     border-radius: 10px;
     background-color: white;
     width: 30%;
-    height: clamp(290px, 39.592vw, 400px);
+    height: clamp(290px, 30vw, 410px);
     vertical-align: top;
     padding: 10px 10px;
     font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
@@ -78,4 +78,30 @@ p.sushi-product-content:after{
 
 p.sushi-product-label {
     font-weight: bold;
+}
+
+@media screen and (max-width: 880px){
+    .sushi-product-card{
+        border-radius: 10px;
+        background-color: white;
+        width: 100%;
+        height: clamp(130px, 18vw, 240px);
+        vertical-align: top;
+        padding: 10px 10px;
+        font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
+        text-align: left;
+        font-size: clamp(0.45em, 0.948vw, 0.9em); /*2.1em == 33.5px*/
+        margin: 5px auto;
+        color: black;
+    }
+
+    img.sushi-product-image {
+        float: left;
+        width: 40%;
+    }
+
+    .product-info {
+        float: right;
+        width: 50%;
+    }
 }

--- a/fluido/css/sushi.css
+++ b/fluido/css/sushi.css
@@ -20,7 +20,7 @@
     border-radius: 10px;
     background-color: white;
     width: 30%;
-    height: clamp(290px, 39.592vw, 400px);
+    height: clamp(290px, 30vw, 410px);
     vertical-align: top;
     padding: 10px 10px;
     font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
@@ -73,4 +73,30 @@ p.sushi-product-content:after{
 
 p.sushi-product-label {
     font-weight: bold;
+}
+
+@media screen and (max-width: 880px){
+    .sushi-product-card{
+        border-radius: 10px;
+        background-color: white;
+        width: 100%;
+        height: clamp(130px, 18vw, 240px);
+        vertical-align: top;
+        padding: 10px 10px;
+        font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
+        text-align: left;
+        font-size: clamp(0.45em, 0.948vw, 0.9em); /*2.1em == 33.5px*/
+        margin: 5px auto;
+        color: black;
+    }
+
+    img.sushi-product-image {
+        float: left;
+        width: 40%;
+    }
+
+    .product-info {
+        float: right;
+        width: 50%;
+    }
 }


### PR DESCRIPTION
Criação de uma query para telas com largura menor que 600px. Essa query torna o arranjo dos sushi-cards em linhas ao invés de colunas. Abaixo estão algumas imagens:

**Sushi Premium:**

![image](https://user-images.githubusercontent.com/63318342/107167798-8a3b0000-6998-11eb-9702-52d8033db62f.png)

![image](https://user-images.githubusercontent.com/63318342/107167816-94f59500-6998-11eb-8de9-d32df5a3d9dc.png)
